### PR TITLE
Update Crashlytics and Fabric version

### DIFF
--- a/Carthage/Crashlytics.json
+++ b/Carthage/Crashlytics.json
@@ -1,4 +1,3 @@
 {
-  "3.10.7": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.7/com.twitter.crashlytics.ios-default.zip",
-  "3.10.5": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.5/com.twitter.crashlytics.ios-default.zip"
+  "3.10.7": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.7/com.twitter.crashlytics.ios-default.zip"
 }

--- a/Carthage/Crashlytics.json
+++ b/Carthage/Crashlytics.json
@@ -1,3 +1,4 @@
 {
+  "3.10.7": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.7/com.twitter.crashlytics.ios-default.zip",
   "3.10.5": "https://kit-downloads.fabric.io/ios/com.twitter.crashlytics.ios/3.10.5/com.twitter.crashlytics.ios-default.zip"
 }

--- a/Carthage/Fabric.json
+++ b/Carthage/Fabric.json
@@ -1,4 +1,3 @@
 {
-  "1.7.11": "https://kit-downloads.fabric.io/ios/io.fabric.sdk.ios/1.7.11/io.fabric.sdk.ios-default.zip",
-  "1.7.9": "https://kit-downloads.fabric.io/ios/io.fabric.sdk.ios/1.7.9/io.fabric.sdk.ios-default.zip"
+  "1.7.11": "https://kit-downloads.fabric.io/ios/io.fabric.sdk.ios/1.7.11/io.fabric.sdk.ios-default.zip"
 }

--- a/Carthage/Fabric.json
+++ b/Carthage/Fabric.json
@@ -1,3 +1,4 @@
 {
+  "1.7.11": "https://kit-downloads.fabric.io/ios/io.fabric.sdk.ios/1.7.11/io.fabric.sdk.ios-default.zip",
   "1.7.9": "https://kit-downloads.fabric.io/ios/io.fabric.sdk.ios/1.7.9/io.fabric.sdk.ios-default.zip"
 }

--- a/Carthage/README.md
+++ b/Carthage/README.md
@@ -7,3 +7,4 @@ binary "https://raw.githubusercontent.com/billioon/specs/master/Carthage/Fabric.
 
 ### Should check
 - [fabric/changelog](https://docs.fabric.io/apple/changelog.html)
+- [Building42/Specs](https://github.com/Building42/Specs)


### PR DESCRIPTION
https://docs.fabric.io/apple/changelog.html#may-24-2018

```
Crashlytics
3.10.7 August 13, 2018
Support for Fabric 1.7.11.

Fabric
1.7.11 August 13, 2018
Add support for upload-symbols on Mojave.
```